### PR TITLE
Add JSON schema as sanity check

### DIFF
--- a/.github/workflows/build-versions-file.yml
+++ b/.github/workflows/build-versions-file.yml
@@ -45,7 +45,7 @@ jobs:
             path: versions.json
             if-no-files-found: error
         
-        - name: Verify JSON files against schema
+        - name: Validate versions.json against schema
           if: steps.rebuild-check.outputs.rebuild == 'true' || github.ref != 'refs/heads/main'
           run: npx -p ajv-cli@3.3.0 ajv -s schema.json -d versions.json
 

--- a/.github/workflows/build-versions-file.yml
+++ b/.github/workflows/build-versions-file.yml
@@ -7,6 +7,8 @@ on:
   push:
     paths:
     - "build_json_map.jl"
+    - "schema.json"
+    - ".github/workflows/build-versions-file.yml"
 
 env:
   aws_region: us-east-1
@@ -43,6 +45,10 @@ jobs:
             path: versions.json
             if-no-files-found: error
         
+        - name: Verify JSON files against schema
+          if: steps.rebuild-check.outputs.rebuild == 'true' || github.ref != 'refs/heads/main'
+          run: npx -p ajv-cli@3.3.0 ajv -s schema.json -d versions.json
+
         # The file will only be uploaded to S3 if the build ran on the main branch.
 
         - name: Configure AWS credentials

--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ Build and deploy Julia's [versions.json](https://julialang-s3.julialang.org/bin/
 More info & discussion: https://github.com/JuliaLang/julia/issues/33817
 
 [`build_json_map.jl`](build_json_map.jl) was written by [@staticfloat](https://github.com/staticfloat).
+
+## JSON Schema
+
+[`schema.json`](schema.json) contains a [JSON Schema](https://json-schema.org/) for the `versions.json` file.
+
+It can be used to validate the versions file or to [generate code](https://json-schema.org/implementations.html) from the schema.
+
+## Third Party Notice
+
+The [schema](schema.json) was generated with [quicktype.io](https://app.quicktype.io/#l=schema).

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,128 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "object",
+    "additionalProperties": {
+        "$ref": "#/definitions/WelcomeValue"
+    },
+    "definitions": {
+        "WelcomeValue": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/File"
+                    }
+                },
+                "stable": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "files",
+                "stable"
+            ],
+            "title": "WelcomeValue"
+        },
+        "File": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triplet": {
+                    "$ref": "#/definitions/Triplet"
+                },
+                "kind": {
+                    "$ref": "#/definitions/Kind"
+                },
+                "arch": {
+                    "$ref": "#/definitions/Arch"
+                },
+                "sha256": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "os": {
+                    "$ref": "#/definitions/OS"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ],
+                    "qt-uri-extensions": [
+                        ".dmg",
+                        ".exe",
+                        ".gz",
+                        ".zip"
+                    ]
+                },
+                "asc": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "arch",
+                "kind",
+                "os",
+                "sha256",
+                "size",
+                "triplet",
+                "url",
+                "version"
+            ],
+            "title": "File"
+        },
+        "Arch": {
+            "type": "string",
+            "enum": [
+                "x86_64",
+                "i686",
+                "powerpc64le",
+                "aarch64",
+                "armv7l"
+            ],
+            "title": "Arch"
+        },
+        "Kind": {
+            "type": "string",
+            "enum": [
+                "archive",
+                "installer"
+            ],
+            "title": "Kind"
+        },
+        "OS": {
+            "type": "string",
+            "enum": [
+                "mac",
+                "winnt",
+                "linux",
+                "freebsd"
+            ],
+            "title": "OS"
+        },
+        "Triplet": {
+            "type": "string",
+            "enum": [
+                "x86_64-apple-darwin14",
+                "x86_64-w64-mingw32",
+                "i686-w64-mingw32",
+                "x86_64-linux-gnu",
+                "i686-linux-gnu",
+                "powerpc64le-linux-gnu",
+                "aarch64-linux-gnu",
+                "armv7l-linux-gnueabihf",
+                "x86_64-unknown-freebsd11.1",
+                "x86_64-linux-musl"
+            ],
+            "title": "Triplet"
+        }
+    }
+}


### PR DESCRIPTION
This should hopefully prevent an incomplete or somehow corrupted versions.json file from being uploaded. It's not a complete check but better than nothing.

Test build on a broken file to check that it fails and cancels the workflow as intended: https://github.com/SaschaMann/Julia-versions.json/runs/1370882552?check_suite_focus=true

As a convenient side effect this also allows people to generate code from the schema (though I'm not sure if there's a Julia library for that yet)